### PR TITLE
fixed client trying to log on the web builds

### DIFF
--- a/grid-master-app/common/GML.gd
+++ b/grid-master-app/common/GML.gd
@@ -11,6 +11,8 @@ var init_done : bool = false
 
 
 func log(message : String) -> void:
+	if (OS.has_feature("web")): return # Don't try to log on the web builds
+	
 	if (init_done == false):
 		init()
 	logfile.store_string(message + "\n")


### PR DESCRIPTION
Fixed bug that caused the web exports of the executioner to throw errors because it was trying to log into a nonexistent log directory