### PR TITLE
GUT CI improvements

### DIFF
--- a/grid-master-app/.gutconfig.json
+++ b/grid-master-app/.gutconfig.json
@@ -1,0 +1,11 @@
+{
+	"dirs": ["res://executioner/tests", "res://editor/tests"],
+	"include_subdirs": true,
+	"prefix": "test_",
+	"suffix": ".gd",
+	"should_exit": true,
+	"exit_on_success": false,
+	"failure_error_types": ["engine", "gut", "push_error"],
+	"no_error_tracking": false,
+	"post_run_script": "res://hooks/gut_post_run_validator.gd"
+}

--- a/grid-master-app/hooks/gut_post_run_validator.gd
+++ b/grid-master-app/hooks/gut_post_run_validator.gd
@@ -1,0 +1,30 @@
+## This is a post run hook that makes sure that when no tests were run
+## GUT will exit with a failing exit code.
+
+extends "res://addons/gut/hook_script.gd"
+
+var EXIT_CODE_ERROR = 1
+var EXIT_CODE_SUCCESS = 0
+
+func run():
+	print("[ HOOK ] Validating test run totals.")
+	
+	var summary = gut.get_summary()
+	var totals = summary.get_totals()
+
+	# If no test were run, ignore the zero failing count
+	# and indicate failing test run with the exit code.
+	if totals.tests == 0:
+		printerr("[ HOOK ] No tests were run.")
+		set_exit_code(EXIT_CODE_ERROR)
+		return
+
+	if totals.warnings != 0:
+		print("[ HOOK ] Some of the tests resulted in warnings (treating warnings as error).")
+		set_exit_code(EXIT_CODE_ERROR)
+	elif totals.failing == 0:
+		print("[ HOOK ] All tests ran successfully.")
+		set_exit_code(EXIT_CODE_SUCCESS)
+	else:
+		printerr("[ HOOK ] Some tests failed.")
+		set_exit_code(EXIT_CODE_ERROR)


### PR DESCRIPTION
# Description

## What

### Add post run hook and GUT config file

The hook makes sure when zero tests are
run the exit code is 1 (fail) which will
reflect the CI result for running empty
set of GUT tests.

The hook also makes sure that the test
warnings are treated as errors (non-permissive
mode), since all the script errors seem
to be shown as warnings even though the
unit test in question fails to execute
and shows only as a warning. This leads
in worst case that some tests don't run
at all and the CI will just show green light.

The config file defines where to look for
the hook, some explicit default rules (so
that they can be easily changed later on)
and where to recursively look for unit
tests that should be run.


## Why

When empty set of tests are run it's inherently indicating a problem. Either there are no tests in the repo, or the a change e.g. in directory structure has made it so that tests aren't run but the exit code is successful when it shouldn't be.

# Changes

- [X] Feature
- [X] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

Describe how you verified the changes.

- [X] Unit tests
- [X] Integration tests
- [X] Manual testing
- [ ] Not tested (explain why)

Testing details:
- 
Unit tests are now looked recursively from (and it worked):
res://editor/test
res://executioner/test

Also, the hook runs and successfully changes the exit code to 1 when no tests have been run.


# Screenshots / Logs (if applicable)

Attach screenshots, recordings, or relevant logs.



# Related Issues

- Closes #
- References #



# Checklist

- [X] My commits follow the commit message guidelines  
- [X] My code follows the project’s coding standards  
- [X] I have added tests where appropriate  
- [X] I have updated documentation where needed  
- [X] All tests pass locally  
- [X] No unnecessary commented-out code remains  

# Additional Notes

Add any extra context, risks, follow-up tasks, or known limitations.
