### PR TITLE
Update the GH action for GUT tests

### DIFF
--- a/.github/workflows/godot-gut-test.yaml
+++ b/.github/workflows/godot-gut-test.yaml
@@ -26,4 +26,4 @@ jobs:
     
     - name: Run executioner Tests
       shell: bash
-      run: godot --headless --path grid-master-app -s addons/gut/gut_cmdln.gd -gdir=res://executioner/tests -ginclude_subdirs -gexit
+      run: godot --headless --path grid-master-app -s addons/gut/gut_cmdln.gd


### PR DESCRIPTION
This commit updates the action file for the GUT tests so that the command line options and paths aren't
explicitly given to gut command since that will
override the gutconfig.json default behavior (before this commit the gut command line tool didn't execute unit test files for the editor).

# Description

## What

This commit updates the action file for the GUT tests so that the command line options and paths aren't
explicitly given to gut command since that will
override the gutconfig.json default behavior (before this commit the gut command line tool didn't execute unit test files for the editor).

## Why

The gutconfig.json should be the only place for specifying options for GUT in order not
to create confusion or unexpected behavior by possibly overriding the default behavior
(in config) by giving explicit arguments to command line tool.

# Changes

- [ ] Feature
- [X] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [X] Not tested (explain why)

The modification of the action file didn't trigger any actions for this pull request.

Instead, I will monitor CI after this commit has been merged to main and if any problems
occur, I will revert this commit.

# Related Issues

[first-gut-tests](https://github.com/Gridmaster-devs/gridmaster/tree/first-gut-tests) was the branch
on which the problems described above were discovered.

# Checklist

- [X] My commits follow the commit message guidelines  
- [X] My code follows the project’s coding standards  
- [X] I have added tests where appropriate  
- [X] I have updated documentation where needed  
- [X] All tests pass locally  
- [X] No unnecessary commented-out code remains  
