### PR TITLE
Adds unit information to units

### DIFF
--- a/grid-master-app/common/popups/popup_manager.gd
+++ b/grid-master-app/common/popups/popup_manager.gd
@@ -16,14 +16,23 @@ func add_popup(popup: PopupWindow) -> void:
 	_popups[popup_name] = popup
 	_containers[popup_name] = new_cont
 	self.visible = true
+	self.mouse_filter = Control.MOUSE_FILTER_STOP
+
+func add_popup_non_blocking(popup: PopupWindow) -> void: 
+	var popup_name: String = popup.get_popup_name()
+	add_child(popup)
+	_popups[popup_name] = popup
+	self.visible = true
+	self.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 
 func close_popup(popup: PopupWindow) -> void: 
 	var popup_name = popup.get_popup_name()
 	_popups[popup_name].queue_free()
-	_containers[popup_name].queue_free()
+	if _containers.has(popup_name):
+		_containers[popup_name].queue_free()
+		_containers.erase(popup_name)
 	_popups.erase(popup_name)
-	_containers.erase(popup_name)
 	if _popups.is_empty(): 
 		self.visible = false
 

--- a/grid-master-app/common/popups/popup_window.gd
+++ b/grid-master-app/common/popups/popup_window.gd
@@ -7,6 +7,7 @@ var _name: String = "unknown"
 ##draggable variables
 var dragging := false
 var drag_offset := Vector2.ZERO
+var _blocking: bool = true
 
 func _gui_input(event):
 	if event is InputEventMouseButton:
@@ -26,10 +27,20 @@ func get_popup_name() -> String:
 	return _name
 
 func add_to_tree() -> void:
-	Global.popup_manager.add_popup(self)
+	if _blocking: 
+		Global.popup_manager.add_popup(self)
+	else:
+		Global.popup_manager.add_popup_non_blocking(self)
+
+
 
 func remove_from_tree() -> void: 
 	Global.popup_manager.close_popup(self)
+
+func set_blocking() -> void:
+	_blocking = true
+func set_unblocking() -> void: 
+	_blocking = false
 
 #CALL SET_POPUP_NAME() when extending
 @abstract func _init() -> void

--- a/grid-master-app/executioner/main/game_master/GameMaster.gd
+++ b/grid-master-app/executioner/main/game_master/GameMaster.gd
@@ -39,6 +39,7 @@ var current_possible_tiles : Array[Vector2i] = [] # Which tiles the unit can mov
 var current_path : Array[Vector2i] = [] # The cumulative path of the unit
 var movement_left : int # How many points of movement the unit still has left
 
+var _unit_information_popup: UnitInformationPopup = null
 
 # ---
 # INFO OVERRIDDEN GODOT ENGINE VIRTUAL METHODS
@@ -484,6 +485,14 @@ func _handle_event_default_in_game(event : StateMachineEvent):
 			moved_unit.current_action = null # clear the current action
 			_custom_graphics.clear_id(moved_unit.getId())
 			
+			#TEMPORARY#
+			if _unit_information_popup != null: 
+				_unit_information_popup.remove_from_tree()
+			_unit_information_popup = preload("res://executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.tscn").instantiate()
+			_unit_information_popup.add_to_tree()
+			_unit_information_popup.set_unit_info(unit)
+			#TEMPORARY#
+			
 			current_possible_tiles = _pathfinder.tiles_from_position(unit.getPosition(), unit.get_move_speed(), unit)
 			movement_left = moved_unit.get_move_speed()
 			
@@ -578,6 +587,8 @@ func _handle_event_unit_move(event : StateMachineEvent) -> void:
 
 
 func _exit_unit_move() -> void:
+	#TODO: 
+	_unit_information_popup.remove_from_tree()
 	_custom_graphics.clear_id(moved_unit.getId())
 	
 	# If the movement action was confirmed, draw the small path for the unit

--- a/grid-master-app/executioner/main/game_master/GameMaster.tscn
+++ b/grid-master-app/executioner/main/game_master/GameMaster.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://cpsdnpca0xb06"]
+[gd_scene load_steps=5 format=3 uid="uid://cpsdnpca0xb06"]
 
 [ext_resource type="Script" uid="uid://bqg42x551mvyw" path="res://executioner/main/game_master/GameMaster.gd" id="1_8ixyn"]
+[ext_resource type="Script" uid="uid://of14uemmvsm2" path="res://common/popups/popup_manager.gd" id="2_ccu5x"]
 [ext_resource type="PackedScene" uid="uid://col1qb3vuji1l" path="res://executioner/main/grid_graphics/GridGraphics.tscn" id="2_ol8qj"]
 [ext_resource type="PackedScene" uid="uid://cehdpht6a7iw8" path="res://common/file_upload_download/file_transfer_manager.tscn" id="3_61xsh"]
 
@@ -8,6 +9,15 @@
 script = ExtResource("1_8ixyn")
 
 [node name="Grid Graphics" parent="." groups=["GridGraphics"] instance=ExtResource("2_ol8qj")]
+
+[node name="Container" type="Container" parent="Grid Graphics"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_ccu5x")
 
 [node name="Dialogs" type="Node" parent="."]
 

--- a/grid-master-app/executioner/main/game_master/Player.gd
+++ b/grid-master-app/executioner/main/game_master/Player.gd
@@ -9,6 +9,18 @@ var player_id : int ## The ID of the player
 var team : Team ## The ID of the team the player is part of
 var computer : bool ## Whether the player is computer or human controlled
 
+# Keeps track of how many of each UnitTypes the player has
+var unit_type_counts: Dictionary[UnitType, int] = {}
+
+
+func increment_unit_count(unit_type: UnitType) -> int:
+	if not unit_type_counts.has(unit_type):
+		unit_type_counts[unit_type] = 1
+	else:
+		unit_type_counts[unit_type] += 1
+	
+	return unit_type_counts[unit_type]
+
 
 static func DEBUG_new_player() -> Player:
 	return Player.new("Debug player", -1, Team.DEBUG_new_team(), false)

--- a/grid-master-app/executioner/main/game_master/Unit.gd
+++ b/grid-master-app/executioner/main/game_master/Unit.gd
@@ -8,6 +8,9 @@ var type : UnitType
 
 var unit_id : int ## The ID of the unit
 
+## Indicates the number of the unit. Is used when displaying unique unit names
+var unit_number: int 
+
 var player : Player ## The player that owns the unit
 var team : Team:
 	get:
@@ -96,6 +99,20 @@ func get_damage() -> int:
 func get_move_speed() -> int:
 	return type.attributes.get(UnitType.UNIT_ATTRIBUTE_TYPE.MOVEMENT_SPEED)
 	
+
+## Returns the unique name of the unit
+func get_unit_name() -> String:
+	var n = unit_number
+	
+	var suffix := "th"
+	if n % 10 == 1 and n % 100 != 11:
+		suffix = "st"
+	elif n % 10 == 2 and n % 100 != 12:
+		suffix = "nd"
+	elif n % 10 == 3 and n % 100 != 13:
+		suffix = "rd"
+	
+	return str(n) + suffix + " " + type.unit_name
 
 ## Returns whether the unit has stopped moving for this turn or not
 func has_stopped() -> bool:
@@ -194,4 +211,5 @@ func _init(unit_type : UnitType, unit_id_p : int, player_p : Player, position : 
 	unit_id = unit_id_p
 	player = player_p
 	type = unit_type
+	unit_number = player.increment_unit_count(type)
 	initFromUnitType()

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.gd
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.gd
@@ -1,0 +1,12 @@
+extends Control
+class_name UnitInformationItem
+
+@onready var _label = $HBoxContainer/Label
+@onready var _data = $HBoxContainer/Label2
+
+
+
+
+func set_information(label: String, data: String) -> void: 
+	_label.text = label
+	_data.text = data

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.gd.uid
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.gd.uid
@@ -1,0 +1,1 @@
+uid://ble5l0n44eq4r

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.tscn
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://ba37au1v7xvw6"]
+
+[ext_resource type="Script" uid="uid://ble5l0n44eq4r" path="res://executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.gd" id="1_4e8sx"]
+
+[node name="UnitInformationItem" type="Control"]
+layout_mode = 3
+anchor_right = 0.16800001
+anchor_bottom = 0.034
+offset_right = -0.5600281
+offset_bottom = 0.27999878
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_4e8sx")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label2" type="Label" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd
@@ -1,0 +1,30 @@
+class_name UnitInformationPopup
+extends PopupWindow
+
+
+@onready var _contents = $EditorPanel/TopVBox/ScrollContainer/ContentsVBox
+
+
+var _data_information_item_map: Dictionary[String, UnitInformationItem]
+
+func _init() -> void: 
+	super.set_popup_name("unit information popup")
+	super.set_unblocking()
+
+
+
+func set_unit_info(unit: Unit) -> void: 
+	# Add the unit name first
+	var name_item: UnitInformationItem = preload("res://executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.tscn").instantiate()
+	_contents.add_child(name_item)
+	name_item.set_information("Name", unit.get_unit_name())
+	_data_information_item_map["Name"] = name_item
+	
+	var unit_type_attribute_names = unit.type.attribute_conversion_table.keys()
+	for attribute_name in unit_type_attribute_names:
+		var attribute_key = unit.type.attribute_conversion_table[attribute_name]
+		var attribute_value = unit.type.attributes[attribute_key]
+		var information_item: UnitInformationItem = preload("res://executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_item.tscn").instantiate()
+		_contents.add_child(information_item)
+		information_item.set_information(attribute_name, str(attribute_value))
+		_data_information_item_map[attribute_name] = information_item

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd.uid
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://c1n7vlij0x03

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.tscn
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=3 format=3 uid="uid://cfgtwy5m7uo2f"]
+
+[ext_resource type="Script" uid="uid://dnjp4sakgqkbp" path="res://executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd" id="1_pnbxe"]
+[ext_resource type="PackedScene" uid="uid://duyxluc3ja031" path="res://editor/editors/common/editor_panel/EditorPanel.tscn" id="2_2vyo1"]
+
+[node name="UnitInformationPopup" type="Control"]
+layout_mode = 3
+anchor_right = 0.18
+anchor_bottom = 0.37300003
+offset_right = -0.6000061
+offset_bottom = 0.15997314
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_pnbxe")
+
+[node name="EditorPanel" parent="." instance=ExtResource("2_2vyo1")]
+layout_mode = 1
+
+[node name="TopLabel" parent="EditorPanel/TopVBox" index="0"]
+text = "Unit Information"
+
+[editable path="EditorPanel"]


### PR DESCRIPTION
# Description
Adds unit information when clicking a unit
## What
Briefly describe what this pull request changes.

- Adds a popup window that shows unit information
- 
- 

## Why
Explain the problem this PR solves or the motivation behind it.

Makes it possible to see the information of own units, so it is clear what properties the unit has

# Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

Describe how you verified the changes.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Not tested (explain why)

Testing details:
- Tested locally in TYTY



# Screenshots / Logs (if applicable)

Attach screenshots, recordings, or relevant logs.



# Related Issues

- Closes #
- References #



# Checklist

- [x] My commits follow the commit message guidelines  
- [x] My code follows the project’s coding standards  
- [ ] I have added tests where appropriate  
- [x] I have updated documentation where needed  
- [x] All tests pass locally  
- [x] No unnecessary commented-out code remains  

# Additional Notes

Add any extra context, risks, follow-up tasks, or known limitations.
