### PR TITLE
Add message dispatcher callback for server side actions, send them to…

### DIFF
--- a/grid-master-app/executioner/main/game_master/GameMaster.gd
+++ b/grid-master-app/executioner/main/game_master/GameMaster.gd
@@ -292,6 +292,11 @@ func end_network_game_turn() -> void:
 
 func _on_turn_ended(state_update: Dictionary):
 	_apply_state_update(state_update)
+	# Broadcast every message received from the server in order (FIFO).
+	if state_update.keys().has("message_queue"):
+		var message_queue: Array[String] = state_update["message_queue"]
+		for message in message_queue:
+			MessageDispatcher.broadcast_message(message)
 
 func _apply_state_update(state_update: Dictionary) -> void:
 	# Create units from the dictionary

--- a/grid-master-app/server/server.gd
+++ b/grid-master-app/server/server.gd
@@ -85,7 +85,13 @@ func _ready():
 	Networking.game_file_requested.connect(_on_game_file_requested)
 	Networking.game_state_requested.connect(_on_game_state_requested)
 	Networking.request_peer_turn_end.connect(_on_team_turn_end)
+	# Connect message dispatcher to local callback that collects all
+	# event messages that are sent to all players when the turn ends.
+	MessageDispatcher.message_broadcast.connect(_on_message_broadcast)
 	start_server()
+
+func _on_message_broadcast(message: String) -> void:
+	server_state.push_message(message)
 
 # TODO: In order to continue an existing game, we can just set the clients
 #		to load the game file and then send the saved game state, which
@@ -139,7 +145,8 @@ func _create_state_update_dict() -> Dictionary:
 			"hp": unit.hp
 		})
 	return {
-		"turn_number": server_state.data_manager.get_turn_number() ,
+		"turn_number": server_state.data_manager.get_turn_number(),
+		"message_queue": server_state.get_message_queue(),
 		"units": units_state
 	}
 
@@ -242,6 +249,9 @@ func _on_team_turn_end(peer_id: int, action_queue: Array) -> void:
 
 	# Send the state update dict to all the clients.
 	Networking.end_turn.rpc(_create_state_update_dict())
+
+	# Clear the action message queue
+	server_state.clear_message_queue()
 
 ## Called when a peer connects to the server
 func _peer_connected(peer_id):

--- a/grid-master-app/server/server_state.gd
+++ b/grid-master-app/server/server_state.gd
@@ -22,6 +22,9 @@ var current_turn: int
 var clients: Dictionary[int, int] = {}
 var teams_ended_turn: Array[int] = []
 
+# FIFO queue for turn messages
+var _message_queue: Array[String] = []
+
 func _init(game_definition: GameDefinitionResource) -> void:
 	self.game_definition_resource = game_definition
 	self.data_manager = GameDataManager.initFromGameDefinition(game_definition)
@@ -64,6 +67,15 @@ func end_team_turn(team_id: int) -> void:
 # Clear the array tracking all the team_id's that have ended their turns.
 func clear_turns() -> void:
 	teams_ended_turn.clear()
+
+func get_message_queue() -> Array[String]:
+	return _message_queue
+
+func push_message(message: String) -> void:
+	_message_queue.push_back(message)
+
+func clear_message_queue() -> void:
+	_message_queue.clear()
 
 func team_has_ended_turn(team_id: int) -> bool:
 	# TODO: Make sure this works.


### PR DESCRIPTION
# Description / What

This commit adds message dispatcher callback for server side actions, sends them to the clients within state_update Dictionary and makes each client broadcast the messages so that they show up in the message window.

## Why
The message window should work and this commit fixes it, since with the server / client implementation the message dispatch events were happening on the server side and weren't connected to any callbacks.

# Changes

- [X] Feature
- [X] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

Describe how you verified the changes.

- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Not tested (explain why)

# Checklist

- [X] My commits follow the commit message guidelines  
- [X] My code follows the project’s coding standards  
- [X] I have added tests where appropriate  
- [X] I have updated documentation where needed  
- [X] All tests pass locally  
- [X] No unnecessary commented-out code remains 