### PR TITLE
Adds basic winning and losing

### DIFF
--- a/grid-master-app/common/game_elimination.gd
+++ b/grid-master-app/common/game_elimination.gd
@@ -1,0 +1,59 @@
+class_name GameElimination
+extends RefCounted
+## Shared win/lose rules: a player is eliminated when they have no living key units.
+
+
+static func is_active_player(player_id: int) -> bool:
+	return player_id > 0
+
+
+static func player_has_key_units(player: Player, units: Dictionary) -> bool:
+	if player.key_unit_type == null:
+		return _player_has_any_living_units(player.player_id, units)
+	for unit: Unit in units.values():
+		if unit.player.player_id != player.player_id:
+			continue
+		if unit.is_dead():
+			continue
+		if unit.type.unit_name == player.key_unit_type.unit_name:
+			return true
+	return false
+
+
+static func _player_has_any_living_units(player_id: int, units: Dictionary) -> bool:
+	for unit: Unit in units.values():
+		if unit.player.player_id == player_id and not unit.is_dead():
+			return true
+	return false
+
+
+static func get_newly_eliminated(players: Dictionary, units: Dictionary, already_eliminated: Array[int]) -> Array[int]:
+	var newly_eliminated: Array[int] = []
+	for player_id in players.keys():
+		if not is_active_player(player_id):
+			continue
+		if already_eliminated.has(player_id):
+			continue
+		var player: Player = players[player_id]
+		if not player_has_key_units(player, units):
+			newly_eliminated.append(player_id)
+	return newly_eliminated
+
+
+static func get_players_with_key_units(players: Dictionary, units: Dictionary, eliminated: Array[int]) -> Array[int]:
+	var alive: Array[int] = []
+	for player_id in players.keys():
+		if not is_active_player(player_id):
+			continue
+		if eliminated.has(player_id):
+			continue
+		if player_has_key_units(players[player_id], units):
+			alive.append(player_id)
+	return alive
+
+
+static func get_winner_player_id(players: Dictionary, units: Dictionary, eliminated: Array[int]) -> int:
+	var alive := get_players_with_key_units(players, units, eliminated)
+	if alive.size() == 1:
+		return alive[0]
+	return -1

--- a/grid-master-app/common/game_elimination.gd.uid
+++ b/grid-master-app/common/game_elimination.gd.uid
@@ -1,0 +1,1 @@
+uid://b2ighu7be3ve2

--- a/grid-master-app/editor/editors/game_editor/game_editor.gd
+++ b/grid-master-app/editor/editors/game_editor/game_editor.gd
@@ -68,6 +68,31 @@ func _reload() -> void:
 func _sync_ui() -> void: 
 	_sync_team_uis()
 	_sync_player_uis()
+	_sync_player_key_units()
+
+func _sync_player_key_units() -> void:
+	for player_ui in _player_uis:
+		_sync_player_key_units_for(player_ui)
+
+func _sync_player_key_units_for(player_ui: PlayerUi) -> void:
+	var team_name: String = player_ui.get_selected_team_name()
+	if team_name == "":
+		player_ui.sync_key_units([])
+	else:
+		player_ui.sync_key_units(_get_team_unit_names(team_name))
+
+func _get_team_unit_names(team_name: String) -> Array:
+	var team_units: Array = []
+	for team_ui in _team_uis:
+		if team_ui.get_team_name() == team_name:
+			team_units = team_ui.get_team_units()
+			break
+	if team_units.is_empty():
+		for team in _teams:
+			if team.get_name() == team_name:
+				team_units = team.get_units()
+				break
+	return _order_unit_names(team_units)
 
 #update map based on map editor
 func _sync_map() -> void:
@@ -157,17 +182,23 @@ func _sync_team_uis() -> void:
 			continue
 		arr.append(unit_name)
 	#sync units
-	for team_ui in _team_uis:
-		team_ui.sync_units(arr)
+	for i in range(_team_uis.size()):
+		_team_uis[i].sync_units(arr)
+		if i < _teams.size():
+			_teams[i].set_units(_team_uis[i].get_team_units())
 
 #players#
 func _add_new_player() -> PlayerUi: 
 	var team_names: Array = []
 	for team in _teams:
 		team_names.append(team.get_name())
-	var new_player_ui: PlayerUi = preload("res://editor/editors/game_editor/player_ui.tscn").instantiate()
+	var new_player_ui: PlayerUi = preload("res://editor/editors/game_editor/player_ui.tscn").instantiate() as PlayerUi
+	if new_player_ui == null:
+		push_error("Failed to instantiate PlayerUi.")
+		return null
 	_players_container.add_child(new_player_ui)
 	new_player_ui.init_teams(team_names)
+	_sync_player_key_units_for(new_player_ui)
 	_player_uis.append(new_player_ui)
 	#signals
 	new_player_ui.team_selected.connect(_on_player_team_selected.bind(new_player_ui))
@@ -217,6 +248,7 @@ func _on_team_name_changed(new_team_name: String, sender: TeamUi) -> void:
 		return
 	_teams[indx].set_name(new_team_name)
 	_sync_player_uis()
+	_sync_player_key_units()
 
 func _on_team_color_changed(new_team_color: Color, sender: TeamUi) -> void: 
 	var indx = _team_uis.find(sender)
@@ -231,6 +263,10 @@ func _on_team_units_changed(new_units: Array, sender: TeamUi) -> void:
 		print("untracked team's signal catched")
 		return
 	_teams[indx].set_units(new_units)
+	var team_name: String = sender.get_team_name()
+	for player_ui in _player_uis:
+		if player_ui.get_selected_team_name() == team_name:
+			_sync_player_key_units_for(player_ui)
 
 #player#
 func _on_player_team_selected(team_name: String, sender: PlayerUi) -> void: 
@@ -241,6 +277,7 @@ func _on_player_team_selected(team_name: String, sender: PlayerUi) -> void:
 	for team in _teams: 
 		if team.get_name() == team_name:
 			_players[indx].set_team(team)
+	_sync_player_key_units_for(sender)
 
 func _on_player_team_unselected(team_name: String, sender: PlayerUi) -> void: 
 	var indx = _player_uis.find(sender)
@@ -249,6 +286,7 @@ func _on_player_team_unselected(team_name: String, sender: PlayerUi) -> void:
 		return
 	if _players[indx].get_team() != null and _players[indx].get_team().get_name() == team_name:
 		_players[indx].set_team(null)
+	_sync_player_key_units_for(sender)
 func _on_player_name_changed(new_player_name: String, sender: PlayerUi) -> void: 
 	var indx = _player_uis.find(sender)
 	if indx == -1 or indx >= _players.size():
@@ -360,6 +398,16 @@ func _get_unit_names() -> Array:
 		var unit_name: String = unit.get_attribute("name").attribute_value
 		data.append(unit_name)
 	return data
+
+func _order_unit_names(unit_names: Array) -> Array:
+	var ordered: Array = []
+	for unit_name in _get_unit_names():
+		if unit_names.has(unit_name) and not ordered.has(unit_name):
+			ordered.append(unit_name)
+	for unit_name in unit_names:
+		if not ordered.has(unit_name):
+			ordered.append(unit_name)
+	return ordered
 
 func _generate_colored_unit_texture(color: Color, unit: Texture2D, alpha_threshold: float = 0.5) -> Texture2D:
 	var img = unit.get_image().duplicate(true)

--- a/grid-master-app/editor/editors/game_editor/game_team.gd
+++ b/grid-master-app/editor/editors/game_editor/game_team.gd
@@ -18,6 +18,8 @@ func set_units(new_units: Array) -> void:
 	_units = new_units
 
 func add_unit(unit_name: String) -> void: 
+	if _units.has(unit_name):
+		return
 	_units.append(unit_name)
 	
 func remove_unit(unit_name: String) -> void: 

--- a/grid-master-app/editor/editors/game_editor/player_ui.gd
+++ b/grid-master-app/editor/editors/game_editor/player_ui.gd
@@ -1,6 +1,7 @@
-extends Control
+extends Node
 class_name PlayerUi
 
+const KEY_UNIT_OPTION_PATH := "EditorPanel/TopVBox/ScrollContainer/ContentsVBox/KeyUnitHBox/OptionButton"
 
 @onready var _teams_vbox = $EditorPanel/TopVBox/ScrollContainer/ContentsVBox/TeamsVbox
 @onready var _player_name_ui = $EditorPanel/TopVBox/ScrollContainer/ContentsVBox/HBoxContainer/LineEdit
@@ -85,16 +86,69 @@ func _team_unchecked(team_name: String) -> void:
 func _on_name_changed(new_name: String) -> void:
 	name_changed.emit(new_name)
 
+func get_selected_team_name() -> String:
+	for team_name in _teams.keys():
+		if _teams[team_name]:
+			return team_name
+	return ""
+
+func _get_key_unit_option() -> OptionButton:
+	return get_node_or_null(KEY_UNIT_OPTION_PATH) as OptionButton
+
+func sync_key_units(unit_names: Array) -> void:
+	if not is_node_ready():
+		call_deferred("sync_key_units", unit_names)
+		return
+	var option := _get_key_unit_option()
+	if option == null:
+		return
+	var selected_name := _get_selected_key_unit_name()
+	option.clear()
+	option.add_item("")
+	for unit_name in unit_names:
+		if unit_name == "" or _option_has_item(option, unit_name):
+			continue
+		option.add_item(unit_name)
+	_set_selected_key_unit_name(selected_name)
+
+func _option_has_item(option: OptionButton, item_text: String) -> bool:
+	for i in range(option.item_count):
+		if option.get_item_text(i) == item_text:
+			return true
+	return false
+
+func _get_selected_key_unit_name() -> String:
+	var option := _get_key_unit_option()
+	if option == null or option.item_count == 0:
+		return ""
+	var index := option.selected
+	if index < 0:
+		return ""
+	return option.get_item_text(index)
+
+func _set_selected_key_unit_name(unit_name: String) -> void:
+	var option := _get_key_unit_option()
+	if option == null:
+		return
+	for i in range(option.item_count):
+		if option.get_item_text(i) == unit_name:
+			option.select(i)
+			return
+	option.select(0)
+
 ##IMPORT / EXPORT
 func import(res: PlayerUiRes) -> void: 
 	reload_teams(res.get_teams())
 	_player_name_ui.text = res.get_player_name()
 	name_changed.emit(res.get_player_name())
-	
+	call_deferred("_apply_imported_key_unit", res.get_key_unit_type_name())
+
+func _apply_imported_key_unit(unit_name: String) -> void:
+	_set_selected_key_unit_name(unit_name)
 
 func export() -> PlayerUiRes: 
 	var res = PlayerUiRes.new()
-	res.init(_teams, _player_name_ui.text)
+	res.init(_teams, _player_name_ui.text, _get_selected_key_unit_name())
 	return res
 
 

--- a/grid-master-app/editor/editors/game_editor/player_ui.tscn
+++ b/grid-master-app/editor/editors/game_editor/player_ui.tscn
@@ -35,4 +35,15 @@ size_flags_horizontal = 3
 layout_mode = 2
 size_flags_vertical = 3
 
+[node name="KeyUnitHBox" type="HBoxContainer" parent="EditorPanel/TopVBox/ScrollContainer/ContentsVBox" index="2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="EditorPanel/TopVBox/ScrollContainer/ContentsVBox/KeyUnitHBox"]
+layout_mode = 2
+text = "Key unit: "
+
+[node name="OptionButton" type="OptionButton" parent="EditorPanel/TopVBox/ScrollContainer/ContentsVBox/KeyUnitHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
 [editable path="EditorPanel"]

--- a/grid-master-app/editor/editors/game_editor/player_ui_res.gd
+++ b/grid-master-app/editor/editors/game_editor/player_ui_res.gd
@@ -6,17 +6,22 @@ extends Resource
 
 @export var _team_information: Dictionary[String, bool]
 @export var _player_name: String
+@export var _key_unit_type_name: String = ""
 
 
-func init(unit_info: Dictionary[String, bool], player_name: String) -> void: 
+func init(unit_info: Dictionary[String, bool], player_name: String, key_unit_type_name: String = "") -> void: 
 	_team_information = unit_info
 	_player_name = player_name
+	_key_unit_type_name = key_unit_type_name
 
 func get_teams() -> Dictionary:
 	return _team_information
 
 func get_player_name() -> String: 
 	return _player_name
+
+func get_key_unit_type_name() -> String:
+	return _key_unit_type_name
 
 
 

--- a/grid-master-app/editor/editors/game_editor/team_ui.gd
+++ b/grid-master-app/editor/editors/game_editor/team_ui.gd
@@ -90,10 +90,12 @@ func _on_color_picker_texture(tex: Texture2D) -> void:
 func _unit_checked(unit_name: String) -> void:
 	_units[unit_name] = true
 	unit_added.emit(unit_name)
+	units_changed.emit(get_team_units())
 
 func _unit_unchecked(unit_name: String) -> void:
 	_units[unit_name] = false
 	unit_removed.emit(unit_name)
+	units_changed.emit(get_team_units())
 
 ##IMPORT / EXPORT
 func export() -> TeamUiRes: 

--- a/grid-master-app/executioner/main/game_master/GameMaster.gd
+++ b/grid-master-app/executioner/main/game_master/GameMaster.gd
@@ -40,6 +40,12 @@ var current_path : Array[Vector2i] = [] # The cumulative path of the unit
 var movement_left : int # How many points of movement the unit still has left
 
 var _unit_information_popup: UnitInformationPopup = null
+var _game_over_popup: GameOverPopup = null
+var _game_over := false
+var _client_player_eliminated := false
+var _eliminated_players: Array[int] = []
+
+const GAME_OVER_POPUP_SCENE := preload("res://executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.tscn")
 
 # ---
 # INFO OVERRIDDEN GODOT ENGINE VIRTUAL METHODS
@@ -69,6 +75,7 @@ func _ready() -> void:
 # TODO Make initial execution path clearer (e.g. who the heck calls this?)
 ## Initializes the data  when a [GameDefinitionResource] is available
 func initGameDataFromGameDefinition(game_definition_resource : GameDefinitionResource) -> void:
+	_reset_game_over_state()
 	
 	#Initialize state
 	data_manager = GameDataManager.initFromGameDefinition(game_definition_resource)
@@ -212,13 +219,17 @@ func load_game_from_file() -> void:
 
 
 func end_turn_local() -> void:
+	if _game_over:
+		return
 	_custom_graphics.clear()
-	#process_end_turn_local()
 	var new_state = process_end_turn_local_builder()
 	data_manager.replace_game_state(new_state)
 	units_changed.emit()
+	_process_post_turn_elimination()
 
 func end_turn() -> void:
+	if _game_over:
+		return
 	if Global.game_type == Global.GameType.SINGLEPLAYER:
 		end_turn_local()
 	elif Global.game_type == Global.GameType.MULTIPLAYER:
@@ -288,6 +299,8 @@ func _on_game_state_received(state_update: Dictionary):
 	switch_gui_scene(IN_GAME_DEFAULT_GUI, data_manager.get_game_name())
 	
 func end_network_game_turn() -> void:
+	if _game_over:
+		return
 	_custom_graphics.clear()
 
 	# Compile locally assigned actions into the queue for server to process
@@ -315,13 +328,140 @@ func end_network_game_turn() -> void:
 
 func _on_turn_ended(state_update: Dictionary):
 	_apply_state_update(state_update)
-	if gui_scene is InGameDefaultGUI:
+	_broadcast_server_messages(state_update)
+	_apply_eliminated_players_from_state(state_update)
+
+	if state_update.get("game_over", false):
+		_finish_game_from_state(state_update)
+		return
+
+	_detect_local_player_elimination(state_update)
+
+	if _should_auto_pass_turn(state_update):
+		_mark_client_player_eliminated()
+		if gui_scene is InGameDefaultGUI:
+			gui_scene.set_eliminated()
+		_auto_pass_turn()
+	elif gui_scene is InGameDefaultGUI:
 		gui_scene.set_turn_active()
-	# Broadcast every message received from the server in order (FIFO).
+
+func _broadcast_server_messages(state_update: Dictionary) -> void:
 	if state_update.keys().has("message_queue"):
 		var message_queue: Array[String] = state_update["message_queue"]
 		for message in message_queue:
 			MessageDispatcher.broadcast_message(message)
+
+func _apply_eliminated_players_from_state(state_update: Dictionary) -> void:
+	if not state_update.has("eliminated_players"):
+		return
+	for player_id in state_update["eliminated_players"]:
+		if not _eliminated_players.has(player_id):
+			_eliminated_players.append(player_id)
+
+func _should_auto_pass_turn(state_update: Dictionary) -> bool:
+	if _game_over:
+		return true
+	if _client_player_eliminated:
+		return true
+	if data_manager == null:
+		return false
+	var my_player_id := data_manager.get_client_player_id()
+	var my_player = data_manager.get_players().get(my_player_id)
+	if my_player == null:
+		return false
+	if state_update.has("eliminated_players") and state_update["eliminated_players"].has(my_player_id):
+		return true
+	return not GameElimination.player_has_key_units(my_player, data_manager.get_units())
+
+func _mark_client_player_eliminated() -> void:
+	if _client_player_eliminated:
+		return
+	_client_player_eliminated = true
+
+func _auto_pass_turn() -> void:
+	if _game_over:
+		return
+	print("[Client] Auto-passing turn (player eliminated or has no key units).")
+	Networking.end_peer_turn.rpc_id(Networking.SERVER_PEER_ID, [])
+	if gui_scene is InGameDefaultGUI:
+		gui_scene.set_waiting()
+
+func _process_post_turn_elimination() -> void:
+	if _game_over or data_manager == null:
+		return
+	var players := data_manager.get_players()
+	var units := data_manager.get_units()
+	for player_id in GameElimination.get_newly_eliminated(players, units, _eliminated_players):
+		_eliminated_players.append(player_id)
+		var player: Player = players[player_id]
+		MessageDispatcher.broadcast_message("%s has been eliminated." % player.player_name)
+		if player_id == data_manager.get_client_player_id():
+			_on_local_player_eliminated()
+	_check_for_victory()
+
+func _on_local_player_eliminated() -> void:
+	if _client_player_eliminated:
+		return
+	_client_player_eliminated = true
+	_display_result_popup("You lost!")
+	if gui_scene is InGameDefaultGUI:
+		gui_scene.set_eliminated()
+
+func _check_for_victory() -> void:
+	if _game_over or data_manager == null:
+		return
+	var players := data_manager.get_players()
+	var units := data_manager.get_units()
+	var winner_id := GameElimination.get_winner_player_id(players, units, _eliminated_players)
+	if winner_id < 0:
+		if GameElimination.get_players_with_key_units(players, units, _eliminated_players).is_empty():
+			_end_game("Draw!")
+		return
+	var winner: Player = players[winner_id]
+	MessageDispatcher.broadcast_message("%s wins!" % winner.player_name)
+	if winner_id == data_manager.get_client_player_id():
+		_end_game("You won!")
+	else:
+		_end_game("You lost!")
+
+func _detect_local_player_elimination(_state_update: Dictionary) -> void:
+	if _client_player_eliminated:
+		return
+	if _eliminated_players.has(data_manager.get_client_player_id()):
+		_on_local_player_eliminated()
+
+func _finish_game_from_state(state_update: Dictionary) -> void:
+	var my_player_id := data_manager.get_client_player_id()
+	var winner_id: int = state_update.get("winner_player_id", -1)
+	if winner_id == my_player_id:
+		_end_game("You won!")
+	elif _eliminated_players.has(my_player_id) or state_update.get("eliminated_players", []).has(my_player_id):
+		if not _client_player_eliminated:
+			_on_local_player_eliminated()
+		_end_game("You lost!", false)
+	else:
+		_end_game("Game over.")
+
+func _end_game(message: String, show_popup: bool = true) -> void:
+	_game_over = true
+	if show_popup:
+		_display_result_popup(message)
+	if gui_scene is InGameDefaultGUI:
+		gui_scene.set_game_over()
+
+func _display_result_popup(message: String) -> void:
+	if _game_over_popup != null:
+		_game_over_popup.remove_from_tree()
+	_game_over_popup = GAME_OVER_POPUP_SCENE.instantiate()
+	_game_over_popup.show_result(message)
+
+func _reset_game_over_state() -> void:
+	_game_over = false
+	_client_player_eliminated = false
+	_eliminated_players.clear()
+	if _game_over_popup != null:
+		_game_over_popup.remove_from_tree()
+		_game_over_popup = null
 
 func _apply_state_update(state_update: Dictionary) -> void:
 	# Create units from the dictionary
@@ -364,6 +504,8 @@ func _apply_state_update(state_update: Dictionary) -> void:
 ## Called by the graphics element or its children via a group.
 ## Calls the appropriate input handler based on the UI state.
 func receive_ui_event(event : StateMachineEvent):
+	if _game_over or _client_player_eliminated:
+		return
 	
 	if (event is MouseMovedToTileEvent):
 		_custom_graphics.draw_tile_cursor(event.new_pos)

--- a/grid-master-app/executioner/main/game_master/Player.gd
+++ b/grid-master-app/executioner/main/game_master/Player.gd
@@ -8,6 +8,7 @@ var player_name : String ## The name of the player
 var player_id : int ## The ID of the player
 var team : Team ## The ID of the team the player is part of
 var computer : bool ## Whether the player is computer or human controlled
+var key_unit_type : UnitType = null ## Losing all living units of this type eliminates the player
 
 # Keeps track of how many of each UnitTypes the player has
 var unit_type_counts: Dictionary[UnitType, int] = {}

--- a/grid-master-app/executioner/main/game_master/game_data_manager.gd
+++ b/grid-master-app/executioner/main/game_master/game_data_manager.gd
@@ -59,8 +59,12 @@ static func initFromGameDefinition(game_definition_resource : GameDefinitionReso
 				player_team = t_name
 		if player_team == null:
 			continue
+		var key_unit_type: UnitType = null
+		var key_unit_name := player.get_key_unit_type_name()
+		if key_unit_name != "" and unit_name_type_dict.has(key_unit_name):
+			key_unit_type = new_game_definition.unit_types[unit_name_type_dict[key_unit_name]]
 		#add the player 
-		var p_id = new_game_definition.add_player(player_name, team_id_dict[player_team], false)
+		var p_id = new_game_definition.add_player(player_name, team_id_dict[player_team], false, key_unit_type)
 		player_name_id_dict[player_name] = p_id
 		#add the client player as the first one
 		if !client_player_added: 

--- a/grid-master-app/executioner/main/game_master/game_definition.gd
+++ b/grid-master-app/executioner/main/game_master/game_definition.gd
@@ -46,9 +46,11 @@ func add_team(team_name : String, color : Color, team_units : Array[UnitType]) -
 
 
 ## Adds a player to the game.
-func add_player(player_name : String, team_id : int, computer : bool) -> int:
+func add_player(player_name : String, team_id : int, computer : bool, key_unit_type: UnitType = null) -> int:
 	var player_id = get_new_player_id()
-	players.set(player_id, Player.new(player_name, player_id, teams.get(team_id), computer))
+	var player = Player.new(player_name, player_id, teams.get(team_id), computer)
+	player.key_unit_type = key_unit_type
+	players.set(player_id, player)
 	return player_id
 
 

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.gd
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.gd
@@ -1,0 +1,24 @@
+extends PopupWindow
+class_name GameOverPopup
+
+@onready var _message_label: Label = $EditorPanel/TopVBox/TopLabel
+@onready var _ok_button: Button = $EditorPanel/TopVBox/ScrollContainer/ContentsVBox/HBoxContainer/Ok
+
+
+func _init() -> void:
+	set_popup_name("game_over_popup")
+
+
+func _ready() -> void:
+	_ok_button.pressed.connect(_on_ok_pressed)
+	center()
+
+
+func show_result(message: String) -> void:
+	add_to_tree()
+	_message_label.text = message
+	center()
+
+
+func _on_ok_pressed() -> void:
+	remove_from_tree()

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.gd.uid
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://donlkjmftjjyw

--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.tscn
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3 uid="uid://cgameoverpopup01"]
+
+[ext_resource type="Script" path="res://executioner/main/game_master/gui_scenes/gui_elements/game_over_popup.gd" id="1_popup"]
+[ext_resource type="PackedScene" uid="uid://duyxluc3ja031" path="res://editor/editors/common/editor_panel/EditorPanel.tscn" id="2_panel"]
+
+[node name="GameOverPopup" type="Control"]
+layout_mode = 3
+anchor_right = 0.2
+anchor_bottom = 0.1
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_popup")
+
+[node name="EditorPanel" parent="." instance=ExtResource("2_panel")]
+layout_mode = 1
+section_headers = Array[String](["HBoxContainer"])
+
+[node name="TopLabel" parent="EditorPanel/TopVBox" index="0"]
+text = "Game Over"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="EditorPanel/TopVBox/ScrollContainer/ContentsVBox" index="0"]
+layout_mode = 2
+
+[node name="Ok" type="Button" parent="EditorPanel/TopVBox/ScrollContainer/ContentsVBox/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "OK"
+
+[editable path="EditorPanel"]

--- a/grid-master-app/executioner/main/game_master/gui_scenes/in_game_default_gui.gd
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/in_game_default_gui.gd
@@ -19,6 +19,14 @@ func set_turn_active() -> void:
 	_end_turn_button.text = "End Turn"
 	_end_turn_button.disabled = false
 
+func set_eliminated() -> void:
+	_end_turn_button.text = "Eliminated"
+	_end_turn_button.disabled = true
+
+func set_game_over() -> void:
+	_end_turn_button.text = "Game Over"
+	_end_turn_button.disabled = true
+
 # Normal _init() does not work when you are instantiating
 # a scene from a file
 func initialize(game_name : Variant) -> void:

--- a/grid-master-app/server/server.gd
+++ b/grid-master-app/server/server.gd
@@ -125,7 +125,7 @@ func _on_game_file_requested(peer_id: int, team_id: int):
 		return
 	if server_state.clients.keys().has(peer_id) and server_state.clients[peer_id] == server_state.TEAM_ID_NOT_SELECTED:
 		# TODO: Check that the given team_id exists.
-		server_state.clients[peer_id] = team_id
+		server_state.assign_peer_to_team(peer_id, team_id)
 		GML.log("Assigned peer %d to team %d" % [peer_id, team_id])
 	else:
 		GML.error(
@@ -181,68 +181,73 @@ func _create_state_update_dict() -> Dictionary:
 	return {
 		"turn_number": server_state.data_manager.get_turn_number(),
 		"message_queue": server_state.get_message_queue(),
+		"eliminated_players": server_state.eliminated_players.duplicate(),
+		"game_over": server_state.game_over,
+		"winner_player_id": server_state.winner_player_id,
 		"units": units_state
 	}
 
 # End the player turn
 func _on_team_turn_end(peer_id: int, action_queue: Array) -> void:
+	if server_state.game_over:
+		return
 	if !server_state.clients.keys().has(peer_id):
 		GML.log("Unknown client tried to end turn. Rejecting.", GML.LogLevel.ERROR)
 		return
 
-	var player_team: Team = server_state.get_player_team_nullable(peer_id)
-	if !player_team:
-		GML.log("Player %d tried to end turn but isn't part of any team." % peer_id, GML.LogLevel.ERROR)
-		return
-
-	GML.log("Peer %d requested team '%s' turn end with %d actions." % [peer_id, player_team.team_name, action_queue.size()], GML.LogLevel.INFO)
-	if !server_state.team_has_ended_turn(player_team.team_id):
-		server_state.end_team_turn(player_team.team_id)
-		GML.log("Validated turn end for peer team %s." % [player_team.team_name], GML.LogLevel.INFO)
-
-		if typeof(action_queue) == TYPE_ARRAY:
-			for dict_action in action_queue:
-				if typeof(dict_action) == TYPE_DICTIONARY and dict_action.get("path") != null and dict_action.get("unit_id") != null:
-					var unit_id = dict_action.get("unit_id")
-					var real_unit = server_state.data_manager.get_unit_by_id(unit_id)
-					#var logical_p_id = dict_action.get("player_id", -1)
-
-					GML.log("Action queued for unit_id: %d (player %d)" % [unit_id, peer_id], GML.LogLevel.INFO)
-
-					# Use team id instead of player id
-					if real_unit != null and real_unit.get_team_id() == player_team.team_id:
-						var path_raw = dict_action.get("path")
-						var typed_path: Array[Vector2i] = []
-						for p in path_raw:
-							typed_path.append(p)
-
-						GML.log("Resolving path %s for unit %d" % [typed_path, unit_id], GML.LogLevel.INFO)
-
-						## Create actions for units.
-						# MoveAction
-						real_unit.current_action = MoveAction.new(
-							typed_path,
-							peer_id,  # Seems that this is not used, so shouldn't matter even if we move units as teams and not as players.
-							real_unit,
-							server_state.data_manager
-						)
-					elif !real_unit:
-						GML.log("Could not find unit with id %d" % unit_id, GML.LogLevel.ERROR)
-					else:
-						GML.log("Unit %d does not match team_id %d" % [unit_id, player_team.team_id], GML.LogLevel.ERROR)
+	if not server_state.players_ended_turn.has(peer_id):
+		if not server_state.is_peer_alive(peer_id):
+			server_state.mark_player_end_turn(peer_id)
+			GML.log("Peer %d auto-passed (player eliminated)." % peer_id, GML.LogLevel.INFO)
 		else:
-			GML.log("Team turn already have been ended.", GML.LogLevel.WARN)
-			return
+			var player_team: Team = server_state.get_player_team_nullable(peer_id)
+			if !player_team:
+				GML.log("Player %d tried to end turn but isn't part of any team." % peer_id, GML.LogLevel.ERROR)
+				return
 
-	# Process the turn only when all peers have submitted their actions
-	if server_state.teams_ended() < server_state.total_teams():
-		GML.log("%d/%d teams have ended their turn. Waiting for the rest to finish their turns." % [server_state.teams_ended(), server_state.total_teams()], GML.LogLevel.INFO)
+			GML.log("Peer %d requested team '%s' turn end with %d actions." % [peer_id, player_team.team_name, action_queue.size()], GML.LogLevel.INFO)
+			server_state.mark_player_end_turn(peer_id)
+			GML.log("Validated turn end for peer team %s." % [player_team.team_name], GML.LogLevel.INFO)
+
+			if typeof(action_queue) == TYPE_ARRAY:
+				for dict_action in action_queue:
+					if typeof(dict_action) == TYPE_DICTIONARY and dict_action.get("path") != null and dict_action.get("unit_id") != null:
+						var unit_id = dict_action.get("unit_id")
+						var real_unit = server_state.data_manager.get_unit_by_id(unit_id)
+
+						GML.log("Action queued for unit_id: %d (player %d)" % [unit_id, peer_id], GML.LogLevel.INFO)
+
+						if real_unit != null and real_unit.get_team_id() == player_team.team_id:
+							var path_raw = dict_action.get("path")
+							var typed_path: Array[Vector2i] = []
+							for p in path_raw:
+								typed_path.append(p)
+
+							GML.log("Resolving path %s for unit %d" % [typed_path, unit_id], GML.LogLevel.INFO)
+
+							real_unit.current_action = MoveAction.new(
+								typed_path,
+								peer_id,
+								real_unit,
+								server_state.data_manager
+							)
+						elif !real_unit:
+							GML.log("Could not find unit with id %d" % unit_id, GML.LogLevel.ERROR)
+						else:
+							GML.log("Unit %d does not match team_id %d" % [unit_id, player_team.team_id], GML.LogLevel.ERROR)
+			else:
+				GML.log("Invalid action queue for peer %d." % peer_id, GML.LogLevel.WARN)
+				return
+
+	# Process the turn only when all connected peers have finished.
+	if not server_state.are_all_peers_finished():
+		GML.log("%d/%d connected peers have ended their turn. Waiting for the rest." % [server_state.players_ended(), server_state.active_clients()], GML.LogLevel.INFO)
 		return
 
 	GML.log("All players have ended their turn. Processing actions..", GML.LogLevel.INFO)
 	
 	# Clear the array of all the teams that have ended their turn
-	server_state.clear_turns()
+	server_state.clear_player_turns()
 	
 	## Finally execute all the actions
 	var unit_array = server_state.data_manager.get_units().values()
@@ -274,6 +279,9 @@ func _on_team_turn_end(peer_id: int, action_queue: Array) -> void:
 		for unit in units_to_be_removed:
 			unit_array.erase(unit)
 			server_state.data_manager.remove_unit(unit)
+		
+	# Check for eliminated players (no key units left) and victory.
+	server_state.process_eliminations_and_victory()
 
 	## Clear turn related information and increment the turn number
 	# Clear actions
@@ -308,4 +316,5 @@ func _peer_disconnected(id):
 	if server_state == null:
 		return
 	server_state.clients.erase(id)
+	server_state.peer_player_ids.erase(id)
 	GML.log("Active clients: %d" % server_state.active_clients())

--- a/grid-master-app/server/server_state.gd
+++ b/grid-master-app/server/server_state.gd
@@ -20,7 +20,13 @@ var current_turn: int
 
 ## peer_id - team_id mapping
 var clients: Dictionary[int, int] = {}
+## peer_id - game player_id mapping (first player on the joined team)
+var peer_player_ids: Dictionary[int, int] = {}
 var teams_ended_turn: Array[int] = []
+var players_ended_turn: Array[int] = []
+var eliminated_players: Array[int] = []
+var game_over: bool = false
+var winner_player_id: int = -1
 
 # FIFO queue for turn messages
 var _message_queue: Array[String] = []
@@ -40,11 +46,21 @@ func join(client_id: int) -> void:
 func active_clients() -> int:
 	return clients.size()
 
-func join_team(peer_id: int, team_id: int) -> void:
+func assign_peer_to_team(peer_id: int, team_id: int) -> void:
 	if !clients.keys().has(peer_id):
-		GML.log("Client %d is already part of a team.", GML.LogLevel.ERROR)
-	else:
-		clients[peer_id] = team_id
+		GML.log("Client %d is not connected." % peer_id, GML.LogLevel.ERROR)
+		return
+	clients[peer_id] = team_id
+	peer_player_ids[peer_id] = _get_first_player_id_for_team(team_id)
+
+func _get_first_player_id_for_team(team_id: int) -> int:
+	for player: Player in data_manager.get_players().values():
+		if player.team != null and player.team.team_id == team_id:
+			return player.player_id
+	return -1
+
+func get_peer_player_id(peer_id: int) -> int:
+	return peer_player_ids.get(peer_id, -1)
 
 func total_teams() -> int:
 	return game_definition_resource.team_uis.size()
@@ -52,19 +68,83 @@ func total_teams() -> int:
 func teams_ended() -> int:
 	return teams_ended_turn.size()
 
+func is_player_eliminated(player_id: int) -> bool:
+	return eliminated_players.has(player_id)
+
+func mark_player_eliminated(player_id: int) -> void:
+	if not eliminated_players.has(player_id):
+		eliminated_players.append(player_id)
+
+## A connected peer is alive when their mapped player is not eliminated.
+func is_peer_alive(peer_id: int) -> bool:
+	var player_id := get_peer_player_id(peer_id)
+	if player_id < 0:
+		return true
+	return not is_player_eliminated(player_id)
+
+func players_ended() -> int:
+	return players_ended_turn.size()
+
+func mark_player_end_turn(peer_id: int) -> void:
+	if not players_ended_turn.has(peer_id):
+		players_ended_turn.append(peer_id)
+
+func clear_player_turns() -> void:
+	players_ended_turn.clear()
+
+func is_peer_finished(peer_id: int) -> bool:
+	if clients[peer_id] == TEAM_ID_NOT_SELECTED:
+		return false
+	if not is_peer_alive(peer_id):
+		return true
+	var player_id := get_peer_player_id(peer_id)
+	if player_id >= 0 and is_player_eliminated(player_id):
+		return true
+	if player_id >= 0:
+		var player: Player = data_manager.get_players().get(player_id)
+		if player != null and not GameElimination.player_has_key_units(player, data_manager.get_units()):
+			if not is_player_eliminated(player_id):
+				mark_player_eliminated(player_id)
+				push_message("%s has been eliminated." % player.player_name)
+			return true
+	return players_ended_turn.has(peer_id)
+
+func are_all_peers_finished() -> bool:
+	for peer_id in clients.keys():
+		if not is_peer_finished(peer_id):
+			return false
+	return true
+
 func get_player_team_nullable(peer_id: int) -> Team:
 	if clients.keys().has(peer_id) and data_manager.get_teams().keys().has(clients[peer_id]):
 		return data_manager.get_teams()[clients[peer_id]]
 	return null
 
-#func is_player_in_team(peer_id: int, team_name: String) -> bool:
-	#var player_team: TeamInfo = get_player_team_nullable(peer_id)
-	#return player_team and player_team.name == team_name
+func process_eliminations_and_victory() -> void:
+	if game_over:
+		return
+	var players := data_manager.get_players()
+	var units := data_manager.get_units()
+	for player_id in GameElimination.get_newly_eliminated(players, units, eliminated_players):
+		mark_player_eliminated(player_id)
+		var player: Player = players[player_id]
+		push_message("%s has been eliminated." % player.player_name)
+	if game_over:
+		return
+	var winner := GameElimination.get_winner_player_id(players, units, eliminated_players)
+	if winner >= 0:
+		game_over = true
+		winner_player_id = winner
+		var winner_player: Player = players[winner]
+		push_message("%s wins!" % winner_player.player_name)
+	elif GameElimination.get_players_with_key_units(players, units, eliminated_players).is_empty():
+		game_over = true
+		winner_player_id = -1
+		push_message("Draw — no players remain.")
 
 func end_team_turn(team_id: int) -> void:
 	teams_ended_turn.append(team_id)
 
-# Clear the array tracking all the team_id's that have ended their turns.
 func clear_turns() -> void:
 	teams_ended_turn.clear()
 
@@ -78,27 +158,14 @@ func clear_message_queue() -> void:
 	_message_queue.clear()
 
 func team_has_ended_turn(team_id: int) -> bool:
-	# TODO: Make sure this works.
 	return teams_ended_turn.has(team_id)
 
-# TODO: Return a game state that can be transfered via the network interface
 func get_serialized_game_change() -> Dictionary:
-	# TODO: Implement
 	return {}
 
 func save(path: String) -> void:
-	# TODO: Implement
 	pass
 
-#static func load(path: String) -> ServerState:
-	## TODO: Implement
-	#pass
-
-# Note: ClientInfo is NOT considered a part of the ServerState,
-# since the peer_id will change every time a player joins the game.
-#
-# Instead, with the new implementation the player always selects the
-# team after they connect to the server.
 const TEAM_ID_NOT_SELECTED = -1
 class ClientInfo:
 	var teamId: int


### PR DESCRIPTION
# Description


## What
Briefly describe what this pull request changes.

- Adds winning and losing to the game
- Adds key unit type to players. If you lose your key unit types, you lose the game
- Fixes the issue where dead players have to end turn

## Why
Explain the problem this PR solves or the motivation behind it.
This PR adds winning and losing to the game, so it is clear who wins and who loses, and prevents the game from continuing after it is over. Dead players don't have to end their turn anymore so the rest of alive players can continue without them. Adds key unit types to players, which makes the game more interesting and fun to play

# Changes

- [ x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

Describe how you verified the changes.

- [ ] Unit tests
- [x ] Integration tests
- [ x] Manual testing
- [ ] Not tested (explain why)

Testing details:
- 



# Screenshots / Logs (if applicable)

Attach screenshots, recordings, or relevant logs.



# Related Issues

- Closes #
- References #



# Checklist

- [x ] My commits follow the commit message guidelines  
- [ x] My code follows the project’s coding standards  
- [ ] I have added tests where appropriate  
- [ ] I have updated documentation where needed  
- [ x] All tests pass locally  
- [ ] No unnecessary commented-out code remains  

# Additional Notes

Add any extra context, risks, follow-up tasks, or known limitations.
