### PR TITLE
Add a label to unit info to show whether a unit is a key unit

### DIFF
--- a/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd
+++ b/grid-master-app/executioner/main/game_master/gui_scenes/gui_elements/unit_information/unit_information_popup.gd
@@ -23,6 +23,12 @@ func set_unit_info(unit: Unit, game_data_manager: GameDataManager) -> void:
 	_contents.add_child(name_item)
 	name_item.set_information("Name", unit.get_unit_name())
 	_data_information_item_map["Name"] = name_item
+
+	var is_key_unit := unit.player.key_unit_type != null and unit.type.unit_name == unit.player.key_unit_type.unit_name
+	var key_unit_item: UnitInformationItem = unit_info_item.instantiate()
+	_contents.add_child(key_unit_item)
+	key_unit_item.set_information("Key unit", "Yes" if is_key_unit else "No")
+	_data_information_item_map["Key unit"] = key_unit_item
 	
 	var unit_type_attribute_names = unit.type.attribute_conversion_table.keys()
 	


### PR DESCRIPTION
# Description

## What
Briefly describe what this pull request changes.

- Adds a text which tells whether a unit is a key unit in the unit info popup
- 
- 

## Why
Explain the problem this PR solves or the motivation behind it.
Adds the label so the player knows, which units are key units and which are not

# Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance



# How was this tested?

Describe how you verified the changes.

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Not tested (explain why)

Testing details:
- 



# Screenshots / Logs (if applicable)

Attach screenshots, recordings, or relevant logs.



# Related Issues

- Closes #
- References #



# Checklist

- [x] My commits follow the commit message guidelines  
- [x] My code follows the project’s coding standards  
- [ ] I have added tests where appropriate  
- [ ] I have updated documentation where needed  
- [x] All tests pass locally  
- [x] No unnecessary commented-out code remains  

# Additional Notes

Add any extra context, risks, follow-up tasks, or known limitations.
